### PR TITLE
fix: send correct `weight` product value

### DIFF
--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -513,7 +513,7 @@ export function UserProvider({ children }: Required<PropsWithChildren>) {
       ...newProduct,
       material: newProduct.material || '',
       size: newProduct.size || '',
-      weight: newProduct.size || '',
+      weight: newProduct.weight || '',
       whatsapp,
       images: imagesObject,
       createdAt: new Date().getTime(),


### PR DESCRIPTION
### Correções

- [x] Removido `size` no envio do produto e enviado o `weight` do produto para que não haja replicagem de valores entre o `size` e o `weight`.